### PR TITLE
[#167725420] Send session token as cookie on success spid login redirect

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -302,7 +302,7 @@ function registerLoginRoute(app: Express): void {
       }
       // The assertion is processed by the assertion consumer service
       // and a response is sent to the client
-      const response = await authController.acs(user, res);
+      const response = await authController.acs(user);
       response.apply(res);
     })(req, res, next);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -277,9 +277,7 @@ function registerLoginRoute(app: Express): void {
     new SessionStorage(),
     new TokenService(),
     TOKEN_DURATION_IN_SECONDS,
-    (token: string) => ({
-      href: CLIENT_SPID_SUCCESS_REDIRECTION_URL.replace("{token}", token)
-    })
+    CLIENT_SPID_SUCCESS_REDIRECTION_URL
   );
 
   // Handle the SAML assertion got from the IdP server
@@ -304,7 +302,7 @@ function registerLoginRoute(app: Express): void {
       }
       // The assertion is processed by the assertion consumer service
       // and a response is sent to the client
-      const response = await authController.acs(user);
+      const response = await authController.acs(user, res);
       response.apply(res);
     })(req, res, next);
   });

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -130,7 +130,7 @@ describe("AuthenticationController#acs", () => {
 
     expect(controller).toBeTruthy();
     expect(res.cookie).toHaveBeenCalledWith("sessionToken", mockSessionToken, {
-      maxAge: tokenDurationSecs
+      maxAge: tokenDurationSecs * 1000
     });
     expect(res.redirect).toHaveBeenCalledWith(
       301,

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -125,7 +125,7 @@ describe("AuthenticationController#acs", () => {
     mockSet.mockReturnValue(Promise.resolve(none));
     mockGetNewToken.mockReturnValueOnce(mockSessionToken);
 
-    const response = await controller.acs(validUserPayload, res);
+    const response = await controller.acs(validUserPayload);
     response.apply(res);
 
     expect(controller).toBeTruthy();
@@ -147,7 +147,7 @@ describe("AuthenticationController#acs", () => {
   it("should fail if userPayload is invalid", async () => {
     const res = mockRes();
 
-    const response = await controller.acs(invalidUserPayload, res);
+    const response = await controller.acs(invalidUserPayload);
     response.apply(res);
 
     expect(controller).toBeTruthy();
@@ -162,7 +162,7 @@ describe("AuthenticationController#acs", () => {
     mockSet.mockReturnValue(Promise.resolve(some(new Error(errorString))));
     const res = mockRes();
 
-    const response = await controller.acs(validUserPayload, res);
+    const response = await controller.acs(validUserPayload);
     response.apply(res);
 
     expect(controller).toBeTruthy();


### PR DESCRIPTION
This PR aims to refactor the redirect response on a successful spid login so that the session token is set as a cookie and not included in the redirection url.