### PR TITLE
[#168476202] Change primary key of Users table from fiscalCode to email

### DIFF
--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -3,14 +3,13 @@
 import { none, some } from "fp-ts/lib/Option";
 import { SpidLevelEnum } from "io-spid-commons";
 import { EmailString, FiscalCode } from "italia-ts-commons/lib/strings";
-import { UrlFromString } from "italia-ts-commons/lib/url";
 
 import mockReq from "../../__mocks__/request";
 import mockRes from "../../__mocks__/response";
 import SessionStorage from "../../services/sessionStorage";
 import TokenService from "../../services/tokenService";
 import { SessionToken } from "../../types/token";
-import { LoggedUser, validateSpidUser } from "../../types/user";
+import { LoggedUser, UserRoleEnum, validateSpidUser } from "../../types/user";
 import AuthenticationController from "../authenticationController";
 
 const aTimestamp = 1518010929530;
@@ -30,11 +29,12 @@ const mockedLoggedUser: LoggedUser = {
   familyName: "Garibaldi",
   firstName: "Giuseppe",
   fiscalCode: aValidFiscalCode,
+  role: UserRoleEnum.ORG_DELEGATE,
   session: {
     createdAt: new Date(aTimestamp),
     deletedAt: null,
+    email: aValidEmailAddress,
     expirationTime: new Date(aTimestamp + tokenDurationSecs * 1000),
-    fiscalCode: aValidFiscalCode,
     token: mockSessionToken
   }
 };

--- a/src/migrations/20190705163318-create-organizations-users-table.ts
+++ b/src/migrations/20190705163318-create-organizations-users-table.ts
@@ -1,5 +1,5 @@
 import { DataTypes, QueryInterface } from "sequelize";
-import { UserRole } from "../models/User";
+import { UserRoleEnum } from "../types/user";
 
 export function up(queryInterface: QueryInterface): Promise<void> {
   return queryInterface.createTable("OrganizationsUsers", {
@@ -23,7 +23,7 @@ export function up(queryInterface: QueryInterface): Promise<void> {
     },
     userRole: {
       allowNull: false,
-      type: new DataTypes.ENUM(...Object.values(UserRole))
+      type: new DataTypes.ENUM(...Object.values(UserRoleEnum))
     }
   });
 }

--- a/src/migrations/20190911125131-change-primary-key-in-users-table.ts
+++ b/src/migrations/20190911125131-change-primary-key-in-users-table.ts
@@ -1,0 +1,248 @@
+import { DataTypes, QueryInterface } from "sequelize";
+
+export function up(queryInterface: QueryInterface): Promise<unknown> {
+  return queryInterface.sequelize.transaction(t =>
+    // remove PK constraint from Users.fiscalCode column
+    queryInterface.sequelize
+      .query(`ALTER TABLE "Users" DROP CONSTRAINT "Users_pkey" CASCADE`, {
+        transaction: t
+      })
+      .then(() =>
+        // add PK constraint to Users.email column
+        queryInterface
+          .addConstraint("Users", ["email"], {
+            name: "Users_pkey",
+            transaction: t,
+            type: "primary key"
+          })
+          // -------------------------------
+          // Update Organizations table
+          // -------------------------------
+          .then(() =>
+            // rename Organizations.legalRepresentativeFiscalCode column into Organizations.legalRepresentativeEmail
+            queryInterface.renameColumn(
+              "Organizations",
+              "legalRepresentativeFiscalCode",
+              "legalRepresentativeEmail",
+              { transaction: t }
+            )
+          )
+          .then(() =>
+            // change the values for the Organizations.legalRepresentativeEmail column in order to keep the referential integrity with the Users table
+            queryInterface.sequelize.query(
+              `UPDATE "Organizations" SET "legalRepresentativeEmail" = (SELECT email FROM "Users" WHERE "Users"."fiscalCode" = "Organizations"."legalRepresentativeEmail")`,
+              {
+                transaction: t
+              }
+            )
+          )
+          .then(() =>
+            // set FK constraint on Organizations.legalRepresentativeEmail
+            queryInterface.changeColumn(
+              "Organizations",
+              "legalRepresentativeEmail",
+              {
+                references: {
+                  key: "email",
+                  model: "Users"
+                },
+                type: new DataTypes.STRING()
+              },
+              { transaction: t }
+            )
+          )
+          // -------------------------------
+          // Update OrganizationsUsers table
+          // -------------------------------
+          .then(() =>
+            // rename OrganizationsUsers.userFiscalCode column into OrganizationsUsers.userEmail
+            queryInterface.renameColumn(
+              "OrganizationsUsers",
+              "userFiscalCode",
+              "userEmail",
+              { transaction: t }
+            )
+          )
+          .then(() =>
+            // change the values for the OrganizationsUser.userEmail column in order to keep the referential integrity with the Users table
+            queryInterface.sequelize.query(
+              `UPDATE "OrganizationsUsers" SET "userEmail" = (SELECT email FROM "Users" WHERE "Users"."fiscalCode" = "OrganizationsUsers"."userEmail")`,
+              {
+                transaction: t
+              }
+            )
+          )
+          .then(() =>
+            // set FK constraint on OrganizationsUser.userEmail
+            queryInterface.changeColumn(
+              "OrganizationsUsers",
+              "userEmail",
+              {
+                references: {
+                  key: "email",
+                  model: "Users"
+                },
+                type: new DataTypes.STRING()
+              },
+              { transaction: t }
+            )
+          )
+          // -------------------------------
+          // Update Sessions table
+          // -------------------------------
+          .then(() =>
+            // rename Sessions.userFiscalCode column into Sessions.userEmail
+            queryInterface.renameColumn(
+              "Sessions",
+              "userFiscalCode",
+              "userEmail",
+              { transaction: t }
+            )
+          )
+          .then(() =>
+            // change the values for the Sessions.userEmail column in order to keep the referential integrity with the Users table
+            queryInterface.sequelize.query(
+              `UPDATE "Sessions" SET "userEmail" = (SELECT email FROM "Users" WHERE "Users"."fiscalCode" = "Sessions"."userEmail")`,
+              { transaction: t }
+            )
+          )
+          .then(() =>
+            // set FK constraint on Sessions.userEmail
+            queryInterface.changeColumn(
+              "Sessions",
+              "userEmail",
+              {
+                references: {
+                  key: "email",
+                  model: "Users"
+                },
+                type: new DataTypes.STRING()
+              },
+              { transaction: t }
+            )
+          )
+      )
+  );
+}
+
+export function down(queryInterface: QueryInterface): Promise<void> {
+  return queryInterface.sequelize.transaction(t =>
+    // remove PK constraint from Users.email column
+    queryInterface.sequelize
+      .query(`ALTER TABLE "Users" DROP CONSTRAINT "Users_pkey" CASCADE`, {
+        transaction: t
+      })
+      .then(() =>
+        // add PK constraint to Users.fiscalCode column
+        queryInterface.addConstraint("Users", ["fiscalCode"], {
+          name: "Users_pkey",
+          transaction: t,
+          type: "primary key"
+        })
+      )
+      // -------------------------------
+      // Update Organizations table
+      // -------------------------------
+      .then(() =>
+        // rename Organizations.legalRepresentativeEmail column into Organizations.legalRepresentativeFiscalCode
+        queryInterface.renameColumn(
+          "Organizations",
+          "legalRepresentativeEmail",
+          "legalRepresentativeFiscalCode",
+          { transaction: t }
+        )
+      )
+      .then(() =>
+        // change the values for the Organizations.legalRepresentativeFiscalCode column in order to keep the referential integrity with the Users table
+        queryInterface.sequelize.query(
+          `UPDATE "Organizations" SET "legalRepresentativeFiscalCode" = (SELECT fiscalCode FROM "Users" WHERE "Users"."email" = "Organizations"."legalRepresentativeFiscalCode")`,
+          {
+            transaction: t
+          }
+        )
+      )
+      .then(() =>
+        // set FK constraint on Organizations.legalRepresentativeEmail
+        queryInterface.changeColumn(
+          "Organizations",
+          "legalRepresentativeFiscalCode",
+          {
+            references: {
+              key: "fiscalCode",
+              model: "Users"
+            },
+            type: new DataTypes.STRING()
+          },
+          { transaction: t }
+        )
+      )
+      // -------------------------------
+      // Update OrganizationsUsers table
+      // -------------------------------
+      .then(() =>
+        // rename OrganizationsUsers.userEmail column into OrganizationsUsers.userFiscalCode
+        queryInterface.renameColumn(
+          "OrganizationsUsers",
+          "userEmail",
+          "userFiscalCode",
+          { transaction: t }
+        )
+      )
+      .then(() =>
+        // change the values for the OrganizationsUser.userFiscalCode column in order to keep the referential integrity with the Users table
+        queryInterface.sequelize.query(
+          `UPDATE "OrganizationsUsers" SET "userFiscalCode" = (SELECT fiscalCode FROM "Users" WHERE "Users"."email" = "OrganizationsUsers"."userFiscalCode")`,
+          {
+            transaction: t
+          }
+        )
+      )
+      .then(() =>
+        // set FK constraint on OrganizationsUser.userEmail
+        queryInterface.changeColumn(
+          "OrganizationsUsers",
+          "userFiscalCode",
+          {
+            references: {
+              key: "fiscalCode",
+              model: "Users"
+            },
+            type: new DataTypes.STRING()
+          },
+          { transaction: t }
+        )
+      )
+
+      // -------------------------------
+      // Update Sessions table
+      // -------------------------------
+      .then(() =>
+        // rename Sessions.userEmail column into Sessions.userFiscalCode
+        queryInterface.renameColumn("Sessions", "userEmail", "userFiscalCode", {
+          transaction: t
+        })
+      )
+      .then(() =>
+        // change the values for the Sessions.userEmail column in order to keep the referential integrity with the Users table
+        queryInterface.sequelize.query(
+          `UPDATE "Sessions" SET "userFiscalCode" = (SELECT fiscalCode FROM "Users" WHERE "Users"."email" = "Sessions"."userFiscalCode")`,
+          { transaction: t }
+        )
+      )
+      .then(() =>
+        // set FK constraint on Sessions.userEmail
+        queryInterface.changeColumn(
+          "Sessions",
+          "userFiscalCode",
+          {
+            references: {
+              key: "fiscalCode",
+              model: "Users"
+            },
+            type: new DataTypes.STRING()
+          },
+          { transaction: t }
+        )
+      )
+  );
+}

--- a/src/migrations/20190912125351-update-user-role-column-in-organizations-users-table.ts
+++ b/src/migrations/20190912125351-update-user-role-column-in-organizations-users-table.ts
@@ -1,0 +1,41 @@
+import { DataTypes, QueryInterface } from "sequelize";
+import { UserRoleEnum } from "../types/user";
+
+export function up(queryInterface: QueryInterface): Promise<void> {
+  return queryInterface.sequelize.transaction(t =>
+    queryInterface
+      .changeColumn(
+        "OrganizationsUsers",
+        "userRole",
+        {
+          allowNull: false,
+          type: new DataTypes.STRING()
+        },
+        { transaction: t }
+      )
+      .then(() =>
+        queryInterface.sequelize.query(
+          `DROP TYPE "enum_OrganizationsUsers_userRole"`,
+          {
+            transaction: t
+          }
+        )
+      )
+      .then(() =>
+        queryInterface.changeColumn(
+          "OrganizationsUsers",
+          "userRole",
+          {
+            allowNull: false,
+            type: new DataTypes.ENUM(),
+            values: [...Object.values(UserRoleEnum)]
+          },
+          { transaction: t }
+        )
+      )
+  );
+}
+
+export function down(_: QueryInterface): Promise<void> {
+  return Promise.resolve();
+}

--- a/src/migrations/20190912132551-add-role-column-to-users-table.ts
+++ b/src/migrations/20190912132551-add-role-column-to-users-table.ts
@@ -1,0 +1,15 @@
+import { DataTypes, QueryInterface } from "sequelize";
+import { UserRoleEnum } from "../types/user";
+
+export function up(queryInterface: QueryInterface): Promise<void> {
+  return queryInterface.addColumn("Users", "role", {
+    allowNull: false,
+    defaultValue: UserRoleEnum.ORG_DELEGATE,
+    type: new DataTypes.ENUM(),
+    values: [...Object.values(UserRoleEnum)]
+  });
+}
+
+export function down(queryInterface: QueryInterface): Promise<void> {
+  return queryInterface.removeColumn("Users", "role");
+}

--- a/src/models/Organization.ts
+++ b/src/models/Organization.ts
@@ -1,4 +1,9 @@
-import { BelongsToManyAddAssociationMixin, DataTypes, Model } from "sequelize";
+import {
+  BelongsToManyAddAssociationMixin,
+  BelongsToSetAssociationMixin,
+  DataTypes,
+  Model
+} from "sequelize";
 import sequelize from "../database/db";
 import { OrganizationUser } from "./OrganizationUser";
 import { User } from "./User";
@@ -19,6 +24,7 @@ export class Organization extends Model {
   public readonly updatedAt!: Date;
 
   public addUser!: BelongsToManyAddAssociationMixin<User, string>;
+  public setLegalRepresentative!: BelongsToSetAssociationMixin<User, string>;
 
   public readonly legalRepresentative!: User;
   public readonly users?: ReadonlyArray<User>;
@@ -34,6 +40,10 @@ export function init(): void {
       ipaCode: {
         allowNull: false,
         primaryKey: true,
+        type: new DataTypes.STRING()
+      },
+      legalRepresentativeEmail: {
+        allowNull: true,
         type: new DataTypes.STRING()
       },
       name: {
@@ -63,14 +73,14 @@ export function createAssociations(): void {
   Organization.belongsToMany(User, {
     as: "users",
     foreignKey: { name: "ipaCode", field: "organizationIpaCode" },
-    otherKey: { name: "fiscalCode", field: "userFiscalCode" },
+    otherKey: { name: "email", field: "userEmail" },
     through: OrganizationUser
   });
   Organization.belongsTo(User, {
     as: "legalRepresentative",
     foreignKey: {
-      field: "legalRepresentativeFiscalCode",
-      name: "legalRepresentativeFiscalCode"
+      field: "legalRepresentativeEmail",
+      name: "legalRepresentativeEmail"
     }
   });
 }

--- a/src/models/OrganizationUser.ts
+++ b/src/models/OrganizationUser.ts
@@ -1,15 +1,15 @@
 import { DataTypes, Model } from "sequelize";
 import sequelize from "../database/db";
-import { UserRole } from "./User";
+import { UserRoleEnum } from "../types/user";
 
 export class OrganizationUser extends Model {
-  public userRole!: UserRole;
+  public userRole!: UserRoleEnum;
 }
 
 export function init(): void {
   OrganizationUser.init(
     {
-      userRole: new DataTypes.ENUM(...Object.values(UserRole))
+      userRole: new DataTypes.ENUM(...Object.values(UserRoleEnum))
     },
     {
       modelName: "OrganizationUser",

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -7,7 +7,7 @@ export class Session extends Model {
   public readonly updatedAt!: Date;
   public readonly expirationTime!: Date;
   public readonly token!: string;
-  public readonly userFiscalCode!: string;
+  public readonly userEmail!: string;
 }
 
 export function init(): void {
@@ -22,9 +22,9 @@ export function init(): void {
         primaryKey: true,
         type: new DataTypes.STRING()
       },
-      userFiscalCode: {
+      userEmail: {
         references: {
-          key: "fiscalCode",
+          key: "email",
           model: "User"
         },
         type: new DataTypes.STRING()
@@ -43,6 +43,6 @@ export function init(): void {
 export function createAssociations(): void {
   Session.belongsTo(User, {
     as: "user",
-    foreignKey: { name: "fiscalCode", field: "userFiscalCode" }
+    foreignKey: { name: "email", field: "userEmail" }
   });
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,13 +1,9 @@
 import { DataTypes, HasManyCreateAssociationMixin, Model } from "sequelize";
 import sequelize from "../database/db";
+import { UserRoleEnum } from "../types/user";
 import { Organization } from "./Organization";
 import { OrganizationUser } from "./OrganizationUser";
 import { Session } from "./Session";
-
-export enum UserRole {
-  ORG_DELEGATE = "ORG_DELEGATE", // Organization delegate
-  ORG_MANAGER = "ORG_MANAGER" // Organization manager
-}
 
 export class User extends Model {
   public email!: string;
@@ -15,6 +11,7 @@ export class User extends Model {
   public firstName!: string;
   public familyName!: string;
   public phoneNumber!: string | null;
+  public role!: UserRoleEnum;
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
 
@@ -38,6 +35,7 @@ export function init(): void {
     {
       email: {
         allowNull: false,
+        primaryKey: true,
         type: new DataTypes.STRING()
       },
       familyName: {
@@ -50,12 +48,15 @@ export function init(): void {
       },
       fiscalCode: {
         allowNull: false,
-        primaryKey: true,
         type: new DataTypes.STRING()
       },
       phoneNumber: {
         allowNull: true,
         type: new DataTypes.STRING()
+      },
+      role: {
+        allowNull: false,
+        type: new DataTypes.ENUM(...Object.values(UserRoleEnum))
       }
     },
     {
@@ -70,16 +71,16 @@ export function init(): void {
 
 export function createAssociations(): void {
   User.belongsToMany(Organization, {
-    foreignKey: { name: "fiscalCode", field: "userFiscalCode" },
+    foreignKey: { name: "email", field: "userEmail" },
     otherKey: { name: "ipaCode", field: "organizationIpaCode" },
     through: OrganizationUser
   });
   User.hasMany(Session, {
     as: "sessions",
-    foreignKey: { name: "fiscalCode", field: "userFiscalCode" }
+    foreignKey: { name: "email", field: "userEmail" }
   });
   User.hasOne(Session, {
     as: "session",
-    foreignKey: { name: "fiscalCode", field: "userFiscalCode" }
+    foreignKey: { name: "email", field: "userEmail" }
   });
 }

--- a/src/services/__tests__/sessionStorage.test.ts
+++ b/src/services/__tests__/sessionStorage.test.ts
@@ -1,6 +1,7 @@
 import { EmailString, FiscalCode } from "italia-ts-commons/lib/strings";
 import * as SequelizeMock from "sequelize-mock";
 import { SessionToken } from "../../types/token";
+import { LoggedUser, UserRoleEnum } from "../../types/user";
 import TokenService from "../tokenService";
 
 const dbMock = new SequelizeMock();
@@ -15,16 +16,16 @@ const dbErrorString = "db error";
 const mockedSession1 = {
   createdAt: new Date(),
   deletedAt: null,
+  email: anEmail,
   expirationTime: new Date(Date.now() + 3600000),
-  fiscalCode: aFiscalCode,
   token: aValidToken
 };
 
 const mockedSession2 = {
   createdAt: new Date(),
   deletedAt: null,
+  email: anEmail,
   expirationTime: new Date(Date.now() + 3600000),
-  fiscalCode: aFiscalCode,
   token: aValidToken
 };
 
@@ -32,7 +33,8 @@ const mockedUserAttributes = {
   email: anEmail,
   familyName: "Colombo",
   firstName: "Cristoforo",
-  fiscalCode: aFiscalCode
+  fiscalCode: aFiscalCode,
+  role: UserRoleEnum.ORG_DELEGATE
 };
 
 const mockedUserModel = dbMock.define("user", mockedUserAttributes);
@@ -81,8 +83,8 @@ mockedUserModel.$queryInterface.$useHandler(
 const mockedSessionModel = dbMock.define("session", {
   createdAt: new Date(),
   deletedAt: null,
+  email: anEmail,
   expirationTime: new Date(Date.now() + 3600000),
-  fiscalCode: aFiscalCode,
   token: aValidToken
 });
 
@@ -93,7 +95,6 @@ jest.mock("../../models/Session", () => () => ({
   Session: mockedSessionModel
 }));
 
-import { LoggedUser } from "../../types/user";
 import SessionStorage from "../sessionStorage";
 
 const sessionStorage = new SessionStorage();

--- a/src/services/sessionStorage.ts
+++ b/src/services/sessionStorage.ts
@@ -83,7 +83,7 @@ export default class SessionStorage {
           }
         ],
         where: {
-          fiscalCode: user.fiscalCode
+          email: user.email
         }
       });
       if (!userWithSessions) {

--- a/src/types/__tests__/user.test.ts
+++ b/src/types/__tests__/user.test.ts
@@ -3,7 +3,7 @@ import { EmailString, FiscalCode } from "italia-ts-commons/lib/strings";
 import mockReq from "../../__mocks__/request";
 
 import { SessionToken } from "../token";
-import { LoggedUser, SpidUser, validateSpidUser } from "../user";
+import { LoggedUser, SpidUser, UserRoleEnum, validateSpidUser } from "../user";
 
 const tokenDurationInSeconds = 300;
 
@@ -36,11 +36,12 @@ const mockedUser: LoggedUser = {
   familyName: "Garibaldi",
   firstName: "Giuseppe Maria",
   fiscalCode: aValidFiscalNumber,
+  role: UserRoleEnum.ORG_DELEGATE,
   session: {
     createdAt: new Date(),
     deletedAt: null,
+    email: aValidEmailAddress,
     expirationTime: new Date(Date.now() + tokenDurationInSeconds * 1000),
-    fiscalCode: aValidFiscalNumber,
     token: "HexToKen" as SessionToken
   }
 };

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -1,6 +1,6 @@
 import * as t from "io-ts";
 import { UTCISODateFromString } from "italia-ts-commons/lib/dates";
-import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { EmailString } from "italia-ts-commons/lib/strings";
 import { SessionToken } from "./token";
 
 /**
@@ -9,8 +9,8 @@ import { SessionToken } from "./token";
 const Session = t.interface({
   createdAt: UTCISODateFromString,
   deletedAt: t.union([UTCISODateFromString, t.null], "DeletionDate"),
+  email: EmailString,
   expirationTime: UTCISODateFromString,
-  fiscalCode: FiscalCode,
   token: SessionToken
 });
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -11,11 +11,22 @@ import { UTCISODateFromString } from "italia-ts-commons/lib/dates";
 import { errorsToReadableMessages } from "italia-ts-commons/lib/reporters";
 import { IResponseErrorValidation } from "italia-ts-commons/lib/responses";
 import { EmailString, FiscalCode } from "italia-ts-commons/lib/strings";
+import { enumType } from "italia-ts-commons/lib/types";
 
 import { log } from "../utils/logger";
 import { withValidatedOrValidationError } from "../utils/responses";
 
 import { NotClosedSession } from "./session";
+
+export enum UserRoleEnum {
+  ORG_DELEGATE = "ORG_DELEGATE", // Organization delegate
+  ORG_MANAGER = "ORG_MANAGER", // Organization manager
+  DEVELOPER = "DEVELOPER",
+  ADMIN = "ADMIN,"
+}
+
+export type UserRole = t.TypeOf<typeof UserRole>;
+export const UserRole = enumType<UserRoleEnum>(UserRoleEnum, "UserRole");
 
 export const LoggedUser = t.interface({
   createdAt: UTCISODateFromString,
@@ -23,6 +34,7 @@ export const LoggedUser = t.interface({
   familyName: t.string,
   firstName: t.string,
   fiscalCode: FiscalCode,
+  role: UserRole,
   session: NotClosedSession
 });
 


### PR DESCRIPTION
This PR aims to change the Primary Key of the Users table: the current Primary Key is the `fiscalCode` column, but such information is not available for all the users, so it will be replaced with the column `email`. All the other related tables and all the models will be also changed accordingly.