### PR TITLE
[#168694479] Set env vars file path in dotenv configuration

### DIFF
--- a/src/database/prepare.ts
+++ b/src/database/prepare.ts
@@ -2,9 +2,11 @@
 // loads all the environment variables from a .env file
 // @see https://github.com/motdotla/dotenv/tree/v6.1.0#how-do-i-use-dotenv-with-import
 import * as dotenv from "dotenv";
-dotenv.config();
-
 import * as path from "path";
+dotenv.config({
+  path: path.resolve(process.cwd(), ".env.example")
+});
+
 import { Sequelize } from "sequelize";
 import * as usync from "umzug-sync";
 import { populateIpaPublicAdministrationTable } from "../services/ipaPublicAdministrationService";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,10 @@
 // loads all the environment variables from a .env file
 // @see https://github.com/motdotla/dotenv/tree/v6.1.0#how-do-i-use-dotenv-with-import
 import * as dotenv from "dotenv";
-dotenv.config();
+import * as path from "path";
+dotenv.config({
+  path: path.resolve(process.cwd(), ".env.example")
+});
 
 import { schedule } from "node-cron";
 import newApp from "./app";


### PR DESCRIPTION
This PR aims to set the env vars file path in _dotenv_ configuration so that when the app is executed without _docker-compose_ the environment variables are correctly loaded from the proper file.