### PR TITLE
Add x-project attribute to reference the IO project.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -3,6 +3,7 @@ info:
   title: "IO onboarding PA API"
   description: "The backend used by the onboarding portal for public administrations of the IO project."
   version: "0.0.1"
+  x-project: io
 servers:
   - url: https://api.pa-onboarding.dev.io.italia.it/
     description: Development environment


### PR DESCRIPTION
## This PR

Adds the info.x-project attribute to reference the IO project, like we do in [daf spec](https://github.com/teamdigitale/api-openapi-samples/blob/master/external-apis/api.daf.teamdigitale.it.yaml.src#L19)