### PR TITLE
[#168832332] Fix session token in cookies

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@ POSTGRES_HOST=database
 POSTGRES_DB=db
 POSTGRES_USER=io-onboarding-pa-api
 POSTGRES_PASSWORD=password
+COOKIE_DOMAIN=.io-onboarding-frontend.com
 CLIENT_DOMAIN=http://localhost:8080
 CLIENT_SPID_LOGIN_REDIRECTION_URL=/login
 CLIENT_SPID_ERROR_REDIRECTION_URL=/error

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The table lists the environment variables needed by the application, that may be
 | POSTGRES_USER                          | PostgreSQL user name to connect as                                                | string |
 | POSTGRES_DB                            | The database name                                                                 | string |
 | CLIENT_DOMAIN                          | The client domain, which will be CORS-enabled                                     | string |
+| COOKIE_DOMAIN                          | The allowed hosts to receive the cookie containing the session token              | string |
 | CLIENT_SPID_LOGIN_REDIRECTION_URL      | The path where the user will be redirected to perform a SPID login                | string |
 | CLIENT_SPID_ERROR_REDIRECTION_URL      | The path where the user will be redirected when en error occurs during SPID login | string |
 | CLIENT_SPID_SUCCESS_REDIRECTION_URL    | The path where the user will be redirected after a successful SPID login          | string |

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -10,10 +10,12 @@ import SessionStorage from "../../services/sessionStorage";
 import TokenService from "../../services/tokenService";
 import { SessionToken } from "../../types/token";
 import { LoggedUser, UserRoleEnum, validateSpidUser } from "../../types/user";
+import { getRequiredEnvVar } from "../../utils/environment";
 import AuthenticationController from "../authenticationController";
 
 const aTimestamp = 1518010929530;
 const tokenDurationSecs = 60;
+const cookieDomain = getRequiredEnvVar("COOKIE_DOMAIN");
 
 const aValidFiscalCode = "GRBGPP87L04L741X" as FiscalCode;
 const aValidEmailAddress = "garibaldi@example.com" as EmailString;
@@ -134,6 +136,7 @@ describe("AuthenticationController#acs", () => {
 
     expect(controller).toBeTruthy();
     expect(res.cookie).toHaveBeenCalledWith("sessionToken", mockSessionToken, {
+      domain: cookieDomain,
       maxAge: tokenDurationSecs * 1000
     });
     expect(res.redirect).toHaveBeenCalledWith(

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -24,6 +24,7 @@ import TokenService from "../services/tokenService";
 import { SuccessResponse } from "../types/commons";
 import { SessionToken } from "../types/token";
 import { validateSpidUser, withUserFromRequest } from "../types/user";
+import { getRequiredEnvVar } from "../utils/environment";
 import { log } from "../utils/logger";
 import { withCatchAsInternalError } from "../utils/responses";
 
@@ -83,6 +84,7 @@ export default class AuthenticationController {
 
     const withCookie = (res: Response) =>
       res.cookie("sessionToken", sessionToken, {
+        domain: getRequiredEnvVar("COOKIE_DOMAIN"),
         maxAge: this.tokenDurationInSeconds * 1000 // Express requires a value in ms
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,3 @@
-// Before running the app and importing any other module,
-// loads all the environment variables from a .env file
-// @see https://github.com/motdotla/dotenv/tree/v6.1.0#how-do-i-use-dotenv-with-import
-import * as dotenv from "dotenv";
-dotenv.config();
-
 import { schedule } from "node-cron";
 import newApp from "./app";
 import { upsertFromIpa } from "./services/ipaPublicAdministrationService";

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,3 +1,8 @@
+// Loads all the environment variables from a .env file before using them
+// @see https://github.com/motdotla/dotenv/tree/v6.1.0#how-do-i-use-dotenv-with-import
+import * as dotenv from "dotenv";
+dotenv.config();
+
 import { log } from "./logger";
 
 /**


### PR DESCRIPTION
This PR aims to fix the return of the session token to the client through a cookie: the `domain` directive is now used in order to make the cookie visible to the client.