### PR TITLE
[#169174405] Fix enum import from autogenerated files in migrations

### DIFF
--- a/src/migrations/20190905174818-add-scope-column-to-organizations-table.ts
+++ b/src/migrations/20190905174818-add-scope-column-to-organizations-table.ts
@@ -1,10 +1,10 @@
 import { DataTypes, QueryInterface } from "sequelize";
-import { OrganizationScope } from "../generated/OrganizationScope";
+import { OrganizationScopeEnum } from "../generated/OrganizationScope";
 
 export function up(queryInterface: QueryInterface): Promise<void> {
   return queryInterface.addColumn("Organizations", "scope", {
     allowNull: false,
-    type: new DataTypes.ENUM(...Object.values(OrganizationScope))
+    type: new DataTypes.ENUM(...Object.values(OrganizationScopeEnum))
   });
 }
 


### PR DESCRIPTION
This PR aims to fix the migrations on an empty db: the migration procedure currently fails because of a wrong import from autogenerated model files.