### PR TITLE
[#169185738] Fix wrong property names in OpenAPI specs file

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -474,7 +474,7 @@ components:
             "2": "indirizzo01@email.pec.it"
           },
           "scope": "NATIONAL",
-          "selected_pec_label": "1",
+          "selected_pec_label": "2",
           "links": [{
             "rel": "self",
             "href": "https://api.pa-onboarding.dev.io.italia.it/public-administrations/c_e043"

--- a/openapi.yml
+++ b/openapi.yml
@@ -181,6 +181,11 @@ components:
         User's fiscal code.
         Its format is defined by the [`FiscalCode`](https://teamdigitale.github.io/io-ts-commons/modules/_strings_.html#fiscalcode)
         constant in [italia-ts-commons](https://teamdigitale.github.io/io-ts-commons) library.
+
+        *NOTE: for historical reasons the labels using this schema are not aligned
+        with the nomenclature defined by the [national ontologies](https://w3id.org/italia).
+        They will be replaced with the correct label
+        of [`tax_code`](https://ontopia-lodview.prod.pdnd.italia.it/onto/CPV/taxCode) at some point in time.*
       format: FiscalCode
       x-import: italia-ts-commons/lib/strings
       example: SPNDNL80R13C555X
@@ -190,6 +195,11 @@ components:
         Organization's fiscal code.
         Its format is defined by the [`OrganizationFiscalCode`](https://teamdigitale.github.io/io-ts-commons/modules/_strings_.html#organizationfiscalcode)
         constant in [italia-ts-commons](https://teamdigitale.github.io/io-ts-commons) library.
+
+        *NOTE: for historical reasons the labels using this schema are not aligned
+        with the nomenclature defined by the [national ontologies](https://w3id.org/italia).
+        They will be replaced with the correct label
+        of [`tax_code`](https://ontopia-lodview.prod.pdnd.italia.it/onto/COV/taxCode) at some point in time.*
       format: OrganizationFiscalCode
       x-import: italia-ts-commons/lib/strings
       example: 01234567890

--- a/openapi.yml
+++ b/openapi.yml
@@ -325,8 +325,8 @@ components:
             given_name:
               type: string
           required:
-            - familyName
-            - givenName
+            - family_name
+            - given_name
         links:
           $ref: '#/components/schemas/Links'
         pecs:
@@ -334,7 +334,7 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/EmailAddress'
       required:
-        - fiscal_Code
+        - fiscal_code
         - ipa_code
         - name
         - legal_representative
@@ -343,7 +343,7 @@ components:
       example:
         [
         {
-          "fiscal_Code": "86000470830",
+          "fiscal_code": "86000470830",
           "ipa_code": "c_e043",
           "legal_representative": {
             "family_name": "Spano'",
@@ -429,7 +429,7 @@ components:
             $ref: '#/components/schemas/EmailAddress'
         scope:
           $ref: '#/components/schemas/OrganizationScope'
-        selectedPecLabel:
+        selected_pec_label:
           type: string
       required:
         - fiscal_code
@@ -470,7 +470,7 @@ components:
             "family_name": "ALI'",
             "given_name": "Gianfranco",
             "fiscal_code": "BCDFGH12A21Z123F",
-            "phoneNumber": "3332222222"
+            "phone_number": "3332222222"
           },
           "name": "Comune di Gioiosa Jonica",
           "pecs": {


### PR DESCRIPTION
This PR aims to rename some properties in OpenAPI specs file that are not in the correct snake_case format.