### PR TITLE
[#169314231] specs file in swagger format

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -129,12 +129,7 @@ paths:
           name: body
           required: true
           schema:
-            type: object
-            properties:
-              work_email:
-                $ref: "#/definitions/EmailAddress"
-            required:
-              - work_email
+            $ref: "#/definitions/WorkEmailObj"
       responses:
         200:
           description: The updated user profile information
@@ -246,6 +241,13 @@ definitions:
         "email": "indirizzo00@email.pec.it",
         "role": "ORG_MANAGER"
       }
+  WorkEmailObj:
+    type: object
+    properties:
+      work_email:
+        $ref: "#/definitions/EmailAddress"
+    required:
+      - work_email
   UserProfile:
     type: object
     properties:
@@ -610,6 +612,7 @@ definitions:
         "scope": "NATIONAL",
         "selected_pec_label": "1"
       }
+
   ProblemJson:
     $ref: "https://raw.githubusercontent.com/teamdigitale/io-functions-commons/v0.5.0/openapi/definitions.yaml#/ProblemJson"
 securityDefinitions:

--- a/openapi.yml
+++ b/openapi.yml
@@ -358,7 +358,7 @@ definitions:
       - ipa_code
       - name
       - legal_representative
-      - link
+      - links
       - pecs
     example:
       [
@@ -449,14 +449,14 @@ definitions:
           $ref: '#/definitions/EmailAddress'
       scope:
         $ref: '#/definitions/OrganizationScope'
-      selected_pec_abel:
+      selected_pec_label:
         type: string
     required:
       - fiscal_code
       - ipa_code
       - name
       - legal_representative
-      - link
+      - links
       - pecs
       - scope
       - selected_pec_label

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+swagger: "2.0"
 info:
   title: "IO onboarding PA API"
   x-summary: >-
@@ -27,11 +27,10 @@ info:
 externalDocs:
   url: https://io.italia.it
   description: IO Project website
-servers:
-  - url: https://api.pa-onboarding.dev.io.italia.it/
-    description: Development environment
-  - url: https://api.pa-onboarding.io.italia.it/
-    description: Production environment
+host: api.pa-onboarding.io.italia.it
+basePath: /
+schemes:
+  - https
 x-commons:
   # This section contains yaml anchors useful to implement common behaviors
   #  in the OAS.
@@ -59,18 +58,16 @@ paths:
             **IdP ID**.
             The id of the SPID IdP to perform the login through.
             *Note: Also a fake IdP with id `xx_tedsstenv2` is available.*
-          schema:
-            type: string
-            x-extensible-enum: ["lepidaid", "infocertid", "sielteid", "namirialid", "timid", "arubaid", "posteid", "intesaid", "spiditalia", "xx_testenv2"]
-          example: posteid
+          type: string
+          x-extensible-enum: ["lepidaid", "infocertid", "sielteid", "namirialid", "timid", "arubaid", "posteid", "intesaid", "spiditalia", "xx_testenv2"]
+          x-example: posteid
         - name: auth_level
           in: query
           required: true
           description: "**SPID level**. The security level of SPID authentication."
-          schema:
-            type: string
-            x-extensible-enum: ["SpidL2", "SpidL3"]
-          example: SpidL2
+          type: string
+          x-extensible-enum: ["SpidL2", "SpidL3"]
+          x-example: SpidL2
       responses:
         302:
           description: Redirection to the login page from the chosen IdP.
@@ -90,11 +87,15 @@ paths:
         the user calling this endpoint is also associated to the organization as its delegate.
       security:
         - bearerAuth: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/OrganizationRegistrationParams"
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          schema:
+            $ref: "#/definitions/OrganizationRegistrationParams"
       responses:
         <<: *common-responses
         201:
@@ -102,54 +103,55 @@ paths:
           headers:
             Location:
               description: URI of the created organization
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Organization"
+              type: string
+          schema:
+            $ref: "#/definitions/Organization"
   /profile:
     get:
       description: |-
         Returns the user profile information.
       security:
         - bearerAuth: []
+      produces:
+        - application/json
       responses:
         <<: *common-responses
         200:
           description: The user profile information
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/UserProfile"
+          schema:
+            $ref: "#/definitions/UserProfile"
     put:
       description: |-
         Updates the user profile.
       security:
         - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                work_email:
-                  $ref: "#/components/schemas/EmailAddress"
-              required:
-                - work_email
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              work_email:
+                $ref: "#/definitions/EmailAddress"
+            required:
+              - work_email
       responses:
         <<: *common-responses
         200:
           description: The updated user profile information
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/UserProfile"
+          schema:
+            $ref: "#/definitions/UserProfile"
   /public-administrations:
     get:
       description: |-
         Returns a list of public administrations that match the searching words.
+      produces:
+        - application/json
       parameters:
         - name: search
           in: query
@@ -157,457 +159,456 @@ paths:
           description: |
             **Public administration name**.
             The API responds with a list of results that match the searching words.
-          schema:
-            $ref: "#/components/schemas/AdministrationSearchParam"
+          pattern: ^[0-9A-Za-z ]{3,}$
+          type: string
       responses:
         <<: *common-responses
         200:
           description: |-
             Public Administrations matching the search criteria.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdministrationSearchResult'
-components:
-  schemas:
-    EmailAddress:
-      type: string
-      format: email
-    FiscalCode:
-      type: string
-      description: |-
-        User's fiscal code.
-        Its format is defined by the [`FiscalCode`](https://teamdigitale.github.io/io-ts-commons/modules/_strings_.html#fiscalcode)
-        constant in [italia-ts-commons](https://teamdigitale.github.io/io-ts-commons) library.
+          schema:
+            $ref: '#/definitions/AdministrationSearchResult'
+definitions:
+  EmailAddress:
+    type: string
+    format: email
+  FiscalCode:
+    type: string
+    description: |-
+      User's fiscal code.
+      Its format is defined by the [`FiscalCode`](https://teamdigitale.github.io/io-ts-commons/modules/_strings_.html#fiscalcode)
+      constant in [italia-ts-commons](https://teamdigitale.github.io/io-ts-commons) library.
 
-        *NOTE: for historical reasons the labels using this schema are not aligned
-        with the nomenclature defined by the [national ontologies](https://w3id.org/italia).
-        They will be replaced with the correct label
-        of [`tax_code`](https://ontopia-lodview.prod.pdnd.italia.it/onto/CPV/taxCode) at some point in time.*
-      format: FiscalCode
-      x-import: italia-ts-commons/lib/strings
-      example: SPNDNL80R13C555X
-    OrganizationFiscalCode:
-      type: string
-      description: |-
-        Organization's fiscal code.
-        Its format is defined by the [`OrganizationFiscalCode`](https://teamdigitale.github.io/io-ts-commons/modules/_strings_.html#organizationfiscalcode)
-        constant in [italia-ts-commons](https://teamdigitale.github.io/io-ts-commons) library.
+      *NOTE: for historical reasons the labels using this schema are not aligned
+      with the nomenclature defined by the [national ontologies](https://w3id.org/italia).
+      They will be replaced with the correct label
+      of [`tax_code`](https://ontopia-lodview.prod.pdnd.italia.it/onto/CPV/taxCode) at some point in time.*
+    format: FiscalCode
+    x-import: italia-ts-commons/lib/strings
+    example: SPNDNL80R13C555X
+  OrganizationFiscalCode:
+    type: string
+    description: |-
+      Organization's fiscal code.
+      Its format is defined by the [`OrganizationFiscalCode`](https://teamdigitale.github.io/io-ts-commons/modules/_strings_.html#organizationfiscalcode)
+      constant in [italia-ts-commons](https://teamdigitale.github.io/io-ts-commons) library.
 
-        *NOTE: for historical reasons the labels using this schema are not aligned
-        with the nomenclature defined by the [national ontologies](https://w3id.org/italia).
-        They will be replaced with the correct label
-        of [`tax_code`](https://ontopia-lodview.prod.pdnd.italia.it/onto/COV/taxCode) at some point in time.*
-      format: OrganizationFiscalCode
-      x-import: italia-ts-commons/lib/strings
-      example: 01234567890
-    OrganizationScope:
-      type: string
-      x-extensible-enum:
-        - "LOCAL"
-        - "NATIONAL"
-    UserRole:
-      type: string
-      x-extensible-enum:
-        - "ORG_DELEGATE"
-        - "ORG_MANAGER"
-        - "DEVELOPER"
-        - "ADMIN"
-    LegalRepresentative:
-      type: object
-      properties:
-        email:
-          $ref: "#/components/schemas/EmailAddress"
-        family_name:
-          <<: *non-empty-string
-        fiscal_code:
-          $ref: "#/components/schemas/FiscalCode"
-        given_name:
-          <<: *non-empty-string
-        phone_number:
-          <<: *non-empty-string
-        role:
-          $ref: "#/components/schemas/UserRole"
-      required:
-        - email
-        - family_name
-        - fiscal_code
-        - given_name
-        - phone_number
-        - role
-      example:
-        {
+      *NOTE: for historical reasons the labels using this schema are not aligned
+      with the nomenclature defined by the [national ontologies](https://w3id.org/italia).
+      They will be replaced with the correct label
+      of [`tax_code`](https://ontopia-lodview.prod.pdnd.italia.it/onto/COV/taxCode) at some point in time.*
+    format: OrganizationFiscalCode
+    x-import: italia-ts-commons/lib/strings
+    example: 01234567890
+  OrganizationScope:
+    type: string
+    x-extensible-enum:
+      - "LOCAL"
+      - "NATIONAL"
+  UserRole:
+    type: string
+    x-extensible-enum:
+      - "ORG_DELEGATE"
+      - "ORG_MANAGER"
+      - "DEVELOPER"
+      - "ADMIN"
+  LegalRepresentative:
+    type: object
+    properties:
+      email:
+        $ref: "#/definitions/EmailAddress"
+      family_name:
+        <<: *non-empty-string
+      fiscal_code:
+        $ref: "#/definitions/FiscalCode"
+      given_name:
+        <<: *non-empty-string
+      phone_number:
+        <<: *non-empty-string
+      role:
+        $ref: "#/definitions/UserRole"
+    required:
+      - email
+      - family_name
+      - fiscal_code
+      - given_name
+      - phone_number
+      - role
+    example:
+      {
+        "family_name": "Spano'",
+        "fiscal_code": "BCDFGH12A21Z123D",
+        "given_name": "Ignazio Alfonso",
+        "phone_number": "5550000000",
+        "email": "indirizzo00@email.pec.it",
+        "role": "ORG_MANAGER"
+      }
+  UserProfile:
+    type: object
+    properties:
+      email:
+        $ref: "#/definitions/EmailAddress"
+      family_name:
+        type: string
+      fiscal_code:
+        $ref: "#/definitions/FiscalCode"
+      given_name:
+        type: string
+      role:
+        $ref: "#/definitions/UserRole"
+      work_email:
+        $ref: "#/definitions/EmailAddress"
+    required:
+      - email
+      - family_name
+      - given_name
+      - fiscal_code
+      - role
+    example:
+      {
+        email: "example@email.com",
+        family_name: "Rossi",
+        fiscal_code: "RSSMRA80A01H501U",
+        given_name: "Mario",
+        role: "ORG_DELEGATE",
+        work_email: "work-email@email.com"
+      }
+  Link:
+    externalDocs:
+      url: https://tools.ietf.org/id/draft-handrews-json-schema-hyperschema-02.html
+      description: HyperSchema internet draft.
+    description: |-
+      As this API wants to drive the consumer in the workflow, we decided to
+      use Link Descriptor Objects defined in the current [json-schema draft](https://json-schema.org/draft/2019-09/links).
+
+      [IANA link relations](https://www.iana.org/assignments/link-relations/link-relations.xhtml)
+      should be used in `rel`.
+    type: object
+    properties:
+      rel:
+        type: string
+      href:
+        type: string
+        format: uri-template
+      title:
+        type: string
+      description:
+        type: string
+      $comment:
+        type: string
+    required:
+      - rel
+      - href
+  Links:
+    type: array
+    items:
+      $ref: '#/definitions/Link'
+    example:
+      - rel: self
+        href: https://api.pa-onboarding.io.italia.it/public-administrations/c_e956
+        description: Agency URL
+  AdministrationSearchParam:
+    type: string
+    pattern: ^[0-9A-Za-z ]{3,}$
+    example: comune gioiosa
+  AdministrationSearchResult:
+    type: object
+    properties:
+      administrations:
+        type: array
+        items:
+          $ref: '#/definitions/FoundAdministration'
+    required:
+      - administrations
+  FoundAdministration:
+    x-one-of: true
+    allOf:
+      - $ref: '#/definitions/FoundNotRegisteredAdministration'
+      - $ref: '#/definitions/FoundRegisteredAdministration'
+  FoundNotRegisteredAdministration:
+    type: object
+    properties:
+      fiscal_code:
+        $ref: "#/definitions/OrganizationFiscalCode"
+      ipa_code:
+        type: string
+      name:
+        type: string
+      legal_representative:
+        type: object
+        properties:
+          family_name:
+            type: string
+          given_name:
+            type: string
+        required:
+          - family_name
+          - given_name
+      links:
+        $ref: '#/definitions/Links'
+      pecs:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/EmailAddress'
+    required:
+      - fiscal_code
+      - ipa_code
+      - name
+      - legal_representative
+      - link
+      - pecs
+    example:
+      [
+      {
+        "fiscal_code": "86000470830",
+        "ipa_code": "c_e043",
+        "legal_representative": {
           "family_name": "Spano'",
-          "fiscal_code": "BCDFGH12A21Z123D",
+          "given_name": "Ignazio Alfonso"
+        },
+        "name": "Comune di Gioiosa Marea",
+        "pecs": {
+          "1": "indirizzo00@email.pec.it",
+          "2": "indirizzo01@email.pec.it"
+        },
+        "links": [{
+          "rel": "self",
+          "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e043"
+        }]
+      },
+      {
+        "fiscal_code": "81000930800",
+        "ipa_code": "c_e044",
+        "legal_representative": {
+          "family_name": "ALI'",
+          "given_name": "Gianfranco"
+        },
+        "name": "Comune di Gioiosa Jonica",
+        "pecs": {
+          "1": "indirizzo10@email.pec.it",
+          "2": "indirizzo11@email.pec.it",
+          "3": "indirizzo12@email.pec.it",
+          "4": "indirizzo13@email.pec.it",
+        },
+        "links": [{
+          "rel": "self",
+          "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e044"
+        }]
+      },
+      {
+        "fiscal_code": "00282520808",
+        "ipa_code": "c_e956",
+        "legal_representative": {
+          "family_name": "Sergio",
+          "given_name": "Mazzia"
+        },
+        "name": "Comune di Marina di Gioiosa Ionica",
+        "pecs": {
+          "1": "indirizzo20@email.pec.it",
+          "2": "indirizzo21@email.pec.it",
+        },
+        "links": [{
+          "rel": "self",
+          "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e0956"
+        }]
+      }
+      ]
+  FoundRegisteredAdministration:
+    type: object
+    properties:
+      fiscal_code:
+        $ref: "#/definitions/OrganizationFiscalCode"
+      ipa_code:
+        type: string
+      name:
+        type: string
+      legal_representative:
+        type: object
+        properties:
+          family_name:
+            type: string
+          fiscal_code:
+            $ref: "#/definitions/FiscalCode"
+          given_name:
+            type: string
+          phone_number:
+            type: string
+        required:
+          - family_name
+          - fiscal_code
+          - given_name
+          - phone_number
+      links:
+        $ref: '#/definitions/Links'
+      pecs:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/EmailAddress'
+      scope:
+        $ref: '#/definitions/OrganizationScope'
+      selected_pec_abel:
+        type: string
+    required:
+      - fiscal_code
+      - ipa_code
+      - name
+      - legal_representative
+      - link
+      - pecs
+      - scope
+      - selected_pec_label
+    example:
+      [
+      {
+        "fiscal_code": "86000470830",
+        "ipa_code": "c_e043",
+        "legal_representative": {
+          "family_name": "Spano'",
           "given_name": "Ignazio Alfonso",
+          "fiscal_code": "BCDFGH12A21Z123D",
+          "phone_number": "3331111111"
+        },
+        "name": "Comune di Gioiosa Marea",
+        "pecs": {
+          "1": "indirizzo00@email.pec.it",
+          "2": "indirizzo01@email.pec.it"
+        },
+        "scope": "NATIONAL",
+        "selected_pec_label": "2",
+        "links": [{
+                    "rel": "self",
+                    "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e043"
+                  }]
+      },
+      {
+        "fiscal_code": "81000930800",
+        "ipa_code": "c_e044",
+        "legal_representative": {
+          "family_name": "ALI'",
+          "given_name": "Gianfranco",
+          "fiscal_code": "BCDFGH12A21Z123F",
+          "phone_number": "3332222222"
+        },
+        "name": "Comune di Gioiosa Jonica",
+        "pecs": {
+          "1": "indirizzo10@email.pec.it",
+          "2": "indirizzo11@email.pec.it",
+          "3": "indirizzo12@email.pec.it",
+          "4": "indirizzo13@email.pec.it",
+        },
+        "scope": "LOCAL",
+        "selected_pec_label": "3",
+        "links": [{
+                    "rel": "self",
+                    "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e044"
+                  }]
+      },
+      {
+        "fiscal_code": "00282520808",
+        "ipa_code": "c_e956",
+        "legal_representative": {
+          "family_name": "Sergio",
+          "given_name": "Mazzia",
+          "fiscal_code": "BCDFGH12A21Z123E",
+          "phone_number": "3333333333"
+        },
+        "name": "Comune di Marina di Gioiosa Ionica",
+        "pecs": {
+          "1": "indirizzo20@email.pec.it",
+          "2": "indirizzo21@email.pec.it",
+        },
+        "scope": "LOCAL",
+        "selected_pec_label": "1",
+        "links": [{
+          "rel": "self",
+          "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e0956"
+        }]
+      }
+      ]
+  Organization:
+    type: object
+    properties:
+      fiscal_code:
+        $ref: "#/definitions/OrganizationFiscalCode"
+      ipa_code:
+        <<: *non-empty-string
+      legal_representative:
+        $ref: "#/definitions/LegalRepresentative"
+      links:
+        $ref: "#/definitions/Links"
+      name:
+        <<: *non-empty-string
+      pec:
+        $ref: "#/definitions/EmailAddress"
+      scope:
+        $ref: '#/definitions/OrganizationScope'
+    required:
+      - fiscal_code
+      - ipa_code
+      - links
+      - name
+      - pec
+      - scope
+    example:
+      {
+        "fiscal_code": "86000470830",
+        "ipa_code": "c_e043",
+        "legal_representative": {
+          "family_name": "Spano'",
+          "given_name": "Ignazio Alfonso",
+          "fiscal_code": "BCDFGH12A21Z123D",
           "phone_number": "5550000000",
           "email": "indirizzo00@email.pec.it",
           "role": "ORG_MANAGER"
-        }
-    UserProfile:
-      type: object
-      properties:
-        email:
-          $ref: "#/components/schemas/EmailAddress"
-        family_name:
-          type: string
-        fiscal_code:
-          $ref: "#/components/schemas/FiscalCode"
-        given_name:
-          type: string
-        role:
-          $ref: "#/components/schemas/UserRole"
-        work_email:
-          $ref: "#/components/schemas/EmailAddress"
-      required:
-        - email
-        - family_name
-        - given_name
-        - fiscal_code
-        - role
-      example:
-        {
-          email: "example@email.com",
-          family_name: "Rossi",
-          fiscal_code: "RSSMRA80A01H501U",
-          given_name: "Mario",
-          role: "ORG_DELEGATE",
-          work_email: "work-email@email.com"
-        }
-    Link:
-      externalDocs:
-        url: https://tools.ietf.org/id/draft-handrews-json-schema-hyperschema-02.html
-        description: HyperSchema internet draft.
-      description: |-
-        As this API wants to drive the consumer in the workflow, we decided to
-        use Link Descriptor Objects defined in the current [json-schema draft](https://json-schema.org/draft/2019-09/links).
-
-        [IANA link relations](https://www.iana.org/assignments/link-relations/link-relations.xhtml)
-        should be used in `rel`.
-      type: object
-      properties:
-        rel:
-          type: string
-        href:
-          type: string
-          format: uri-template
-        title:
-          type: string
-        description:
-          type: string
-        $comment:
-          type: string
-      required:
-        - rel
-        - href
-    Links:
-      type: array
-      items:
-        $ref: '#/components/schemas/Link'
-      example:
-        - rel: self
-          href: https://api.pa-onboarding.dev.io.italia.it/public-administrations/c_e956
-          description: Agency URL
-    AdministrationSearchParam:
-      type: string
-      pattern: ^[0-9A-Za-z ]{3,}$
-      example: comune gioiosa
-    AdministrationSearchResult:
-      type: object
-      properties:
-        administrations:
-          type: array
-          items:
-            $ref: '#/components/schemas/FoundAdministration'
-      required:
-        - administrations
-    FoundAdministration:
-      oneOf:
-        - $ref: '#/components/schemas/FoundNotRegisteredAdministration'
-        - $ref: '#/components/schemas/FoundRegisteredAdministration'
-    FoundNotRegisteredAdministration:
-      type: object
-      properties:
-        fiscal_code:
-          $ref: "#/components/schemas/OrganizationFiscalCode"
-        ipa_code:
-          type: string
-        name:
-          type: string
-        legal_representative:
-          type: object
-          properties:
-            family_name:
-              type: string
-            given_name:
-              type: string
-          required:
-            - family_name
-            - given_name
-        links:
-          $ref: '#/components/schemas/Links'
-        pecs:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/EmailAddress'
-      required:
-        - fiscal_code
-        - ipa_code
-        - name
-        - legal_representative
-        - link
-        - pecs
-      example:
-        [
-        {
-          "fiscal_code": "86000470830",
-          "ipa_code": "c_e043",
-          "legal_representative": {
-            "family_name": "Spano'",
-            "given_name": "Ignazio Alfonso"
-          },
-          "name": "Comune di Gioiosa Marea",
-          "pecs": {
-            "1": "indirizzo00@email.pec.it",
-            "2": "indirizzo01@email.pec.it"
-          },
-          "links": [{
-            "rel": "self",
-            "href": "https://api.pa-onboarding.dev.io.italia.it/public-administrations/c_e043"
-          }]
         },
-        {
-          "fiscal_code": "81000930800",
-          "ipa_code": "c_e044",
-          "legal_representative": {
-            "family_name": "ALI'",
-            "given_name": "Gianfranco"
-          },
-          "name": "Comune di Gioiosa Jonica",
-          "pecs": {
-            "1": "indirizzo10@email.pec.it",
-            "2": "indirizzo11@email.pec.it",
-            "3": "indirizzo12@email.pec.it",
-            "4": "indirizzo13@email.pec.it",
-          },
-          "links": [{
-            "rel": "self",
-            "href": "https://api.pa-onboarding.dev.io.italia.it/public-administrations/c_e044"
-          }]
+        "name": "Comune di Gioiosa Marea",
+        "pec": "indirizzo00@email.pec.it",
+        "scope": "NATIONAL"
+      }
+  OrganizationRegistrationParams:
+    type: object
+    properties:
+      ipa_code:
+        <<: *non-empty-string
+      legal_representative:
+        type: object
+        properties:
+          family_name:
+            <<: *non-empty-string
+          given_name:
+            <<: *non-empty-string
+          fiscal_code:
+            $ref: "#/definitions/FiscalCode"
+          phone_number:
+            <<: *non-empty-string
+        required:
+          - family_name
+          - given_name
+          - fiscal_code
+          - phone_number
+      scope:
+        $ref: '#/definitions/OrganizationScope'
+      selected_pec_label:
+        <<: *non-empty-string
+    required:
+      - ipa_code
+      - legal_representative
+      - scope
+      - selected_pec_label
+    example:
+      {
+        "ipa_code": "c_e043",
+        "legal_representative": {
+          "family_name": "Spano'",
+          "given_name": "Ignazio Alfonso",
+          "fiscal_code": "BCDFGH12A21Z123D",
+          "phone_number": "3331111111"
         },
-        {
-          "fiscal_code": "00282520808",
-          "ipa_code": "c_e956",
-          "legal_representative": {
-            "family_name": "Sergio",
-            "given_name": "Mazzia"
-          },
-          "name": "Comune di Marina di Gioiosa Ionica",
-          "pecs": {
-            "1": "indirizzo20@email.pec.it",
-            "2": "indirizzo21@email.pec.it",
-          },
-          "links": [{
-            "rel": "self",
-            "href": "https://api.pa-onboarding.dev.io.italia.it/public-administrations/c_e0956"
-          }]
-        }
-        ]
-    FoundRegisteredAdministration:
-      type: object
-      properties:
-        fiscal_code:
-          $ref: "#/components/schemas/OrganizationFiscalCode"
-        ipa_code:
-          type: string
-        name:
-          type: string
-        legal_representative:
-          type: object
-          properties:
-            family_name:
-              type: string
-            fiscal_code:
-              $ref: "#/components/schemas/FiscalCode"
-            given_name:
-              type: string
-            phone_number:
-              type: string
-          required:
-            - family_name
-            - fiscal_code
-            - given_name
-            - phone_number
-        links:
-          $ref: '#/components/schemas/Links'
-        pecs:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/EmailAddress'
-        scope:
-          $ref: '#/components/schemas/OrganizationScope'
-        selected_pec_label:
-          type: string
-      required:
-        - fiscal_code
-        - ipa_code
-        - name
-        - legal_representative
-        - link
-        - pecs
-        - scope
-        - selected_pec_label
-      example:
-        [
-        {
-          "fiscal_code": "86000470830",
-          "ipa_code": "c_e043",
-          "legal_representative": {
-            "family_name": "Spano'",
-            "given_name": "Ignazio Alfonso",
-            "fiscal_code": "BCDFGH12A21Z123D",
-            "phone_number": "3331111111"
-          },
-          "name": "Comune di Gioiosa Marea",
-          "pecs": {
-            "1": "indirizzo00@email.pec.it",
-            "2": "indirizzo01@email.pec.it"
-          },
-          "scope": "NATIONAL",
-          "selected_pec_label": "2",
-          "links": [{
-            "rel": "self",
-            "href": "https://api.pa-onboarding.dev.io.italia.it/public-administrations/c_e043"
-          }]
-        },
-        {
-          "fiscal_code": "81000930800",
-          "ipa_code": "c_e044",
-          "legal_representative": {
-            "family_name": "ALI'",
-            "given_name": "Gianfranco",
-            "fiscal_code": "BCDFGH12A21Z123F",
-            "phone_number": "3332222222"
-          },
-          "name": "Comune di Gioiosa Jonica",
-          "pecs": {
-            "1": "indirizzo10@email.pec.it",
-            "2": "indirizzo11@email.pec.it",
-            "3": "indirizzo12@email.pec.it",
-            "4": "indirizzo13@email.pec.it",
-          },
-          "scope": "LOCAL",
-          "selected_pec_label": "3",
-          "links": [{
-            "rel": "self",
-            "href": "https://api.pa-onboarding.dev.io.italia.it/public-administrations/c_e044"
-          }]
-        },
-        {
-          "fiscal_code": "00282520808",
-          "ipa_code": "c_e956",
-          "legal_representative": {
-            "family_name": "Sergio",
-            "given_name": "Mazzia",
-            "fiscal_code": "BCDFGH12A21Z123E",
-            "phone_number": "3333333333"
-          },
-          "name": "Comune di Marina di Gioiosa Ionica",
-          "pecs": {
-            "1": "indirizzo20@email.pec.it",
-            "2": "indirizzo21@email.pec.it",
-          },
-          "scope": "LOCAL",
-          "selected_pec_label": "1",
-          "links": [{
-            "rel": "self",
-            "href": "https://api.pa-onboarding.dev.io.italia.it/public-administrations/c_e0956"
-          }]
-        }
-        ]
-    Organization:
-      type: object
-      properties:
-        fiscal_code:
-          $ref: "#/components/schemas/OrganizationFiscalCode"
-        ipa_code:
-          <<: *non-empty-string
-        legal_representative:
-          $ref: "#/components/schemas/LegalRepresentative"
-        links:
-          $ref: "#/components/schemas/Links"
-        name:
-          <<: *non-empty-string
-        pec:
-          $ref: "#/components/schemas/EmailAddress"
-        scope:
-          $ref: '#/components/schemas/OrganizationScope'
-      required:
-        - fiscal_code
-        - ipa_code
-        - links
-        - name
-        - pec
-        - scope
-      example:
-        {
-          "fiscal_code": "86000470830",
-          "ipa_code": "c_e043",
-          "legal_representative": {
-            "family_name": "Spano'",
-            "given_name": "Ignazio Alfonso",
-            "fiscal_code": "BCDFGH12A21Z123D",
-            "phone_number": "5550000000",
-            "email": "indirizzo00@email.pec.it",
-            "role": "ORG_MANAGER"
-          },
-          "name": "Comune di Gioiosa Marea",
-          "pec": "indirizzo00@email.pec.it",
-          "scope": "NATIONAL"
-        }
-    OrganizationRegistrationParams:
-      type: object
-      properties:
-        ipa_code:
-          <<: *non-empty-string
-        legal_representative:
-          type: object
-          properties:
-            family_name:
-              <<: *non-empty-string
-            given_name:
-              <<: *non-empty-string
-            fiscal_code:
-              $ref: "#/components/schemas/FiscalCode"
-            phone_number:
-              <<: *non-empty-string
-          required:
-            - family_name
-            - given_name
-            - fiscal_code
-            - phone_number
-        scope:
-          $ref: '#/components/schemas/OrganizationScope'
-        selected_pec_label:
-          <<: *non-empty-string
-      required:
-        - ipa_code
-        - legal_representative
-        - scope
-        - selected_pec_label
-      example:
-        {
-          "ipa_code": "c_e043",
-          "legal_representative": {
-            "family_name": "Spano'",
-            "given_name": "Ignazio Alfonso",
-            "fiscal_code": "BCDFGH12A21Z123D",
-            "phone_number": "3331111111"
-          },
-          "scope": "NATIONAL",
-          "selected_pec_label": "1"
-        }
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
+        "scope": "NATIONAL",
+        "selected_pec_label": "1"
+      }
+securityDefinitions:
+  bearerAuth:
+    in: header
+    name: Authorization
+    type: apiKey

--- a/openapi.yml
+++ b/openapi.yml
@@ -34,13 +34,6 @@ schemes:
 x-commons:
   # This section contains yaml anchors useful to implement common behaviors
   #  in the OAS.
-  common-responses: &common-responses
-    400:
-      $ref: https://teamdigitale.github.io/openapi/0.0.5/definitions.yaml#/responses/400BadRequest
-    429:
-      $ref: https://teamdigitale.github.io/openapi/0.0.5/definitions.yaml#/responses/429TooManyRequests
-    503:
-      $ref: https://teamdigitale.github.io/openapi/0.0.5/definitions.yaml#/responses/503ServiceUnavailable
   non-empty-string: &non-empty-string
     type: string
     minLength: 1
@@ -77,7 +70,6 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        <<: *common-responses
         200:
           description: Successful response
   /organizations:
@@ -98,7 +90,6 @@ paths:
           schema:
             $ref: "#/definitions/OrganizationRegistrationParams"
       responses:
-        <<: *common-responses
         201:
           description: The registered organization
           headers:
@@ -107,6 +98,8 @@ paths:
               type: string
           schema:
             $ref: "#/definitions/Organization"
+        400:
+          $ref: "#/responses/400"
   /profile:
     get:
       description: |-
@@ -117,7 +110,6 @@ paths:
       produces:
         - application/json
       responses:
-        <<: *common-responses
         200:
           description: The user profile information
           schema:
@@ -144,11 +136,12 @@ paths:
             required:
               - work_email
       responses:
-        <<: *common-responses
         200:
           description: The updated user profile information
           schema:
             $ref: "#/definitions/UserProfile"
+        400:
+          $ref: "#/responses/400"
   /public-administrations:
     get:
       description: |-
@@ -166,12 +159,18 @@ paths:
           pattern: ^[0-9A-Za-z ]{3,}$
           type: string
       responses:
-        <<: *common-responses
         200:
           description: |-
             Public Administrations matching the search criteria.
           schema:
             $ref: '#/definitions/AdministrationSearchResult'
+        400:
+          $ref: '#/responses/400'
+responses:
+  400:
+    description: Bad request
+    schema:
+      $ref: "#/definitions/ProblemJson"
 definitions:
   EmailAddress:
     type: string
@@ -611,6 +610,8 @@ definitions:
         "scope": "NATIONAL",
         "selected_pec_label": "1"
       }
+  ProblemJson:
+    $ref: "https://raw.githubusercontent.com/teamdigitale/io-functions-commons/v0.5.0/openapi/definitions.yaml#/ProblemJson"
 securityDefinitions:
   bearerAuth:
     in: header

--- a/openapi.yml
+++ b/openapi.yml
@@ -363,24 +363,6 @@ definitions:
       - links
       - pecs
     example:
-      [
-      {
-        "fiscal_code": "86000470830",
-        "ipa_code": "c_e043",
-        "legal_representative": {
-          "family_name": "Spano'",
-          "given_name": "Ignazio Alfonso"
-        },
-        "name": "Comune di Gioiosa Marea",
-        "pecs": {
-          "1": "indirizzo00@email.pec.it",
-          "2": "indirizzo01@email.pec.it"
-        },
-        "links": [{
-          "rel": "self",
-          "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e043"
-        }]
-      },
       {
         "fiscal_code": "81000930800",
         "ipa_code": "c_e044",
@@ -399,25 +381,7 @@ definitions:
           "rel": "self",
           "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e044"
         }]
-      },
-      {
-        "fiscal_code": "00282520808",
-        "ipa_code": "c_e956",
-        "legal_representative": {
-          "family_name": "Sergio",
-          "given_name": "Mazzia"
-        },
-        "name": "Comune di Marina di Gioiosa Ionica",
-        "pecs": {
-          "1": "indirizzo20@email.pec.it",
-          "2": "indirizzo21@email.pec.it",
-        },
-        "links": [{
-          "rel": "self",
-          "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e0956"
-        }]
       }
-      ]
   FoundRegisteredAdministration:
     type: object
     properties:
@@ -463,28 +427,6 @@ definitions:
       - scope
       - selected_pec_label
     example:
-      [
-      {
-        "fiscal_code": "86000470830",
-        "ipa_code": "c_e043",
-        "legal_representative": {
-          "family_name": "Spano'",
-          "given_name": "Ignazio Alfonso",
-          "fiscal_code": "BCDFGH12A21Z123D",
-          "phone_number": "3331111111"
-        },
-        "name": "Comune di Gioiosa Marea",
-        "pecs": {
-          "1": "indirizzo00@email.pec.it",
-          "2": "indirizzo01@email.pec.it"
-        },
-        "scope": "NATIONAL",
-        "selected_pec_label": "2",
-        "links": [{
-                    "rel": "self",
-                    "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e043"
-                  }]
-      },
       {
         "fiscal_code": "81000930800",
         "ipa_code": "c_e044",
@@ -504,32 +446,10 @@ definitions:
         "scope": "LOCAL",
         "selected_pec_label": "3",
         "links": [{
-                    "rel": "self",
-                    "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e044"
-                  }]
-      },
-      {
-        "fiscal_code": "00282520808",
-        "ipa_code": "c_e956",
-        "legal_representative": {
-          "family_name": "Sergio",
-          "given_name": "Mazzia",
-          "fiscal_code": "BCDFGH12A21Z123E",
-          "phone_number": "3333333333"
-        },
-        "name": "Comune di Marina di Gioiosa Ionica",
-        "pecs": {
-          "1": "indirizzo20@email.pec.it",
-          "2": "indirizzo21@email.pec.it",
-        },
-        "scope": "LOCAL",
-        "selected_pec_label": "1",
-        "links": [{
           "rel": "self",
-          "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e0956"
+          "href": "https://api.pa-onboarding.io.italia.it/public-administrations/c_e044"
         }]
       }
-      ]
   Organization:
     type: object
     properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -41,8 +41,6 @@ x-commons:
       $ref: https://teamdigitale.github.io/openapi/0.0.5/definitions.yaml#/responses/429TooManyRequests
     503:
       $ref: https://teamdigitale.github.io/openapi/0.0.5/definitions.yaml#/responses/503ServiceUnavailable
-    default:
-      $ref: https://teamdigitale.github.io/openapi/0.0.5/definitions.yaml#/responses/default
   non-empty-string: &non-empty-string
     type: string
     minLength: 1

--- a/openapi.yml
+++ b/openapi.yml
@@ -50,6 +50,7 @@ paths:
   /login:
     get:
       description: Redirects the user to the login page of the chosen SPID IdP.
+      operationId: login
       parameters:
         - name: entity_id
           in: query
@@ -74,6 +75,7 @@ paths:
   /logout:
     post:
       description: Logs the user out
+      operationId: logout
       security:
         - bearerAuth: []
       responses:
@@ -85,6 +87,7 @@ paths:
       description: |-
         Creates a new organization associated with its legal responsible,
         the user calling this endpoint is also associated to the organization as its delegate.
+      operationId: registerOrganization
       security:
         - bearerAuth: []
       consumes:
@@ -110,6 +113,7 @@ paths:
     get:
       description: |-
         Returns the user profile information.
+      operationId: getProfile
       security:
         - bearerAuth: []
       produces:
@@ -123,6 +127,7 @@ paths:
     put:
       description: |-
         Updates the user profile.
+      operationId: updateProfile
       security:
         - bearerAuth: []
       consumes:
@@ -150,6 +155,7 @@ paths:
     get:
       description: |-
         Returns a list of public administrations that match the searching words.
+      operationId: searchPublicAdministration
       produces:
         - application/json
       parameters:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "io-ts": "1.8.5",
     "io-ts-types": "^0.4.7",
     "italia-ts-commons": "^5.1.5",
-    "italia-utils": "aymen94/io-utils-build",
+    "italia-utils": "^4.1.0",
     "logform": "^2.1.2",
     "node-cron": "^2.0.3",
     "node-fetch": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,17 +2772,6 @@ italia-utils@^4.1.0:
     swagger-parser "^7.0.0"
     yargs "^11.1.0"
 
-italia-utils@aymen94/io-utils-build:
-  version "4.1.0"
-  resolved "https://codeload.github.com/aymen94/io-utils-build/tar.gz/4a59a9bc23301bd30d37542dccb3faf8394f618f"
-  dependencies:
-    fs-extra "^6.0.0"
-    italia-ts-commons "^5.0.1"
-    nunjucks "^3.1.2"
-    prettier "^1.12.1"
-    swagger-parser "^7.0.0"
-    yargs "^11.1.0"
-
 jest-changed-files@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.8.0.tgz#7e7eb21cf687587a85e50f3d249d1327e15b157b"


### PR DESCRIPTION
This PR aims to change the OpenAPI specification file format from openapi to swagger in order to generate both model data types and request types by using the stable version of `io-utils` library.
Among the changes, some typos and wrong examples in the specs file have been fixed.