### PR TITLE
[#169479287] Refactor definition of bearerAuth security schema in specs

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -538,5 +538,6 @@ components:
         }
   securitySchemes:
     bearerAuth:
-      type: http
-      scheme: bearer
+      type: apiKey
+      name: Authorization
+      in: header


### PR DESCRIPTION
This PR aims to refactor the definition of bearerAuth security schema in specs file, in order to fix the lack of authentication info in the generated request types.