### PR TITLE
[#169591573] Add condition to send work email change notification

### DIFF
--- a/.env
+++ b/.env
@@ -18,9 +18,9 @@ SPID_TESTENV_URL=http://spid-testenv2:8088
 IDP_METADATA_URL=https://registry.spid.gov.it/metadata/idp/spid-entities-idps.xml
 TOKEN_DURATION_IN_SECONDS=3600
 
-EMAIL_PASSWORD=password
-EMAIL_USER=user
-EMAIL_SMTP_HOST=smtp.host
-EMAIL_SMTP_PORT=465
-EMAIL_SMTP_SECURE=true
-EMAIL_SENDER=indirizzo@mittente.it
+EMAIL_PASSWORD=PincoPallinoQualsiasi
+EMAIL_USER=pinco.pallino.qualsiasi@hotmail.com
+EMAIL_SMTP_HOST=smtp.office365.com
+EMAIL_SMTP_PORT=587
+EMAIL_SMTP_SECURE=false
+EMAIL_SENDER=IO<pinco.pallino.qualsiasi@hotmail.com>

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -62,6 +62,9 @@ export default class ProfileController {
                 "%s",
                 user.givenName
               );
+              // TODO:
+              //  refactor this kind of tasks with some external asynchronous worker processes linked to a shared queue.
+              //  @see https://www.pivotaltracker.com/story/show/169620861
               this.emailService
                 .send({
                   html: emailText,

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -57,26 +57,28 @@ export default class ProfileController {
             workEmail
           );
           return errorResponseOrSuccessResponse.map(response => {
-            const emailText = localeIt.profileController.editProfile.notificationEmail.content.replace(
-              "%s",
-              user.givenName
-            );
-            // tslint:disable-next-line:no-floating-promises
-            this.emailService
-              .send({
-                html: emailText,
-                subject:
-                  localeIt.profileController.editProfile.notificationEmail
-                    .subject,
-                text: emailText,
-                to: workEmail
-              })
-              .catch(error =>
-                log.error(
-                  "Failed to send email notification for work email change. %s",
-                  error
-                )
+            if (response.value.work_email !== response.value.email) {
+              const emailText = localeIt.profileController.editProfile.notificationEmail.content.replace(
+                "%s",
+                user.givenName
               );
+              // tslint:disable-next-line:no-floating-promises
+              this.emailService
+                .send({
+                  html: emailText,
+                  subject:
+                    localeIt.profileController.editProfile.notificationEmail
+                      .subject,
+                  text: emailText,
+                  to: workEmail
+                })
+                .catch(error =>
+                  log.error(
+                    "Failed to send email notification for work email change. %s",
+                    error
+                  )
+                );
+            }
             return response;
           }).value;
         }

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -62,7 +62,6 @@ export default class ProfileController {
                 "%s",
                 user.givenName
               );
-              // tslint:disable-next-line:no-floating-promises
               this.emailService
                 .send({
                   html: emailText,


### PR DESCRIPTION
This PR aims to add a check after a successful work email update, in order to skip the email notification send when the addresses of updated work email and user email are the same.