### PR TITLE
[#169591647] Public administration emails for development environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ SPID_AUTOLOGIN=
 SPID_TESTENV_URL=http://spid-testenv2:8088
 IDP_METADATA_URL=https://registry.spid.gov.it/metadata/idp/spid-entities-idps.xml
 TOKEN_DURATION_IN_SECONDS=3600
+INDICEPA_ADMINISTRATIONS_URL=https://raw.githubusercontent.com/teamdigitale/io-onboarding-pa-api/169591647-public-administration-emails-for-development-environment/development-data/administrations.txt
 
 EMAIL_PASSWORD=password
 EMAIL_USER=user

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The table lists the environment variables needed by the application, that may be
 | EMAIL_SMTP_PORT                        | The port of the SMTP server                                                       | int    |
 | EMAIL_SMTP_SECURE                      | If set to true, uses TLS in SMTP connection                                       | boolean|
 | EMAIL_SENDER                           | The email address of the sender                                                   | string |
+| INDICEPA_ADMINISTRATIONS_URL           | The URL to download the public administrations info from                              | string |
 
 ## Production deployments
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,4 @@
-// Endpoint to search the public administrations from IPA
-export const IPA_ELASTICSEARCH_ENDPOINT =
-  "https://elasticsearch.developers.italia.it";
+import { getRequiredEnvVar } from "./utils/environment";
 
 // Endpoint to retrieve the public administrations from IPA
-export const INDICEPA_URL =
-  "https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt";
+export const INDICEPA_URL = getRequiredEnvVar("INDICEPA_ADMINISTRATIONS_URL");


### PR DESCRIPTION
This PR aims to make the URL of public administration data file configurable so that locally and in development environment it's possible to read data from a file containing mocked email addresses, in order not to use the real ones.