### PR TITLE
[#169726186] Send registration documents

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -111,6 +111,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Organization"
+  /organizations/{ipaCode}/signed-documents:
+    post:
+      description: Send via email the registration documents of the organization
+      operationId: sendDocuments
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: ipaCode
+          in: path
+          required: true
+          description: The IPA code of the organization the documents belong to
+          schema:
+            <<: *non-empty-string
+      responses:
+        <<: *common-responses
+        204:
+          description: No content
+        403:
+          description: Forbidden
+        404:
+          description: Organization not found
   /organizations/{ipaCode}/documents/{documentName}:
     get:
       description: Returns the requested document

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,14 +4,27 @@ import * as express from "express";
 import { Express, NextFunction, Request, Response } from "express";
 import { fromNullable } from "fp-ts/lib/Option";
 import * as fs from "fs";
-import { getErrorCodeFromResponse, SamlAttribute, SpidPassportBuilder } from "io-spid-commons";
+import {
+  getErrorCodeFromResponse,
+  SamlAttribute,
+  SpidPassportBuilder
+} from "io-spid-commons";
 import * as passport from "passport";
 
 import { init as initIpaPublicAdministration } from "./models/IpaPublicAdministration";
-import { createAssociations as createOrganizationAssociations, init as initOrganization } from "./models/Organization";
+import {
+  createAssociations as createOrganizationAssociations,
+  init as initOrganization
+} from "./models/Organization";
 import { init as initOrganizationUser } from "./models/OrganizationUser";
-import { createAssociations as createSessionAssociations, init as initSession } from "./models/Session";
-import { createAssociations as createUserAssociations, init as initUser } from "./models/User";
+import {
+  createAssociations as createSessionAssociations,
+  init as initSession
+} from "./models/Session";
+import {
+  createAssociations as createUserAssociations,
+  init as initUser
+} from "./models/User";
 import { log } from "./utils/logger";
 
 import AuthenticationController from "./controllers/authenticationController";

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,27 +4,14 @@ import * as express from "express";
 import { Express, NextFunction, Request, Response } from "express";
 import { fromNullable } from "fp-ts/lib/Option";
 import * as fs from "fs";
-import {
-  getErrorCodeFromResponse,
-  SamlAttribute,
-  SpidPassportBuilder
-} from "io-spid-commons";
+import { getErrorCodeFromResponse, SamlAttribute, SpidPassportBuilder } from "io-spid-commons";
 import * as passport from "passport";
 
 import { init as initIpaPublicAdministration } from "./models/IpaPublicAdministration";
-import {
-  createAssociations as createOrganizationAssociations,
-  init as initOrganization
-} from "./models/Organization";
+import { createAssociations as createOrganizationAssociations, init as initOrganization } from "./models/Organization";
 import { init as initOrganizationUser } from "./models/OrganizationUser";
-import {
-  createAssociations as createSessionAssociations,
-  init as initSession
-} from "./models/Session";
-import {
-  createAssociations as createUserAssociations,
-  init as initUser
-} from "./models/User";
+import { createAssociations as createSessionAssociations, init as initSession } from "./models/Session";
+import { createAssociations as createUserAssociations, init as initUser } from "./models/User";
 import { log } from "./utils/logger";
 
 import AuthenticationController from "./controllers/authenticationController";
@@ -178,7 +165,10 @@ function registerRoutes(
   );
 
   const documentService = new DocumentService();
-  const organizationController = new OrganizationController(documentService);
+  const organizationController = new OrganizationController(
+    documentService,
+    emailServiceInstance
+  );
 
   app.post(
     "/organizations",
@@ -193,6 +183,15 @@ function registerRoutes(
     "/organizations/:ipaCode/documents/:fileName",
     bearerTokenAuth,
     toExpressHandler(organizationController.getDocument, organizationController)
+  );
+
+  app.post(
+    "/organizations/:ipaCode/signed-documents",
+    bearerTokenAuth,
+    toExpressHandler(
+      organizationController.sendDocuments,
+      organizationController
+    )
   );
 
   app.get(

--- a/src/controllers/__tests__/organizationController.test.ts
+++ b/src/controllers/__tests__/organizationController.test.ts
@@ -5,6 +5,7 @@ import {
   ResponseSuccessRedirectToResource
 } from "italia-ts-commons/lib/responses";
 import { EmailString, NonEmptyString } from "italia-ts-commons/lib/strings";
+import * as mockFs from "mock-fs";
 import * as nodemailer from "nodemailer";
 import mockReq from "../../__mocks__/request";
 import { LegalRepresentative } from "../../generated/LegalRepresentative";
@@ -15,12 +16,10 @@ import { OrganizationScopeEnum } from "../../generated/OrganizationScope";
 import { UserRoleEnum } from "../../generated/UserRole";
 import { Organization as OrganizationModel } from "../../models/Organization";
 import DocumentService from "../../services/documentService";
+import EmailService from "../../services/emailService";
 import * as organizationService from "../../services/organizationService";
 import { LoggedUser } from "../../types/user";
 import OrganizationController from "../organizationController";
-
-import * as mockFs from "mock-fs";
-import EmailService from "../../services/emailService";
 
 const mockedLoggedDelegate: LoggedUser = {
   createdAt: new Date(1518010929530),

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -5,6 +5,13 @@ export default {
         "Contratto di adesione tra \"IO - L'app per i servizi pubblici\" e %s per l'utilizzo dei servizi forniti dalla piattaforma.",
       delegation:
         "Io sottoscritto %legalRepresentative%, in qualità di responsabile legale dell'ente %organizationName%, delego a %delegate% la gestione dell'attività dell'ente sulla piattaforma IO."
+    },
+    sendDocuments: {
+      registrationEmail: {
+        content:
+          "In allegato la documentazione necessaria per la registrazione di questo ente presso la piattaforma IO.",
+        subject: "Registrazione presso la piattaforma IO"
+      }
     }
   },
   profileController: {

--- a/src/services/organizationService.ts
+++ b/src/services/organizationService.ts
@@ -359,6 +359,7 @@ export async function getOrganizationInstanceFromDelegateEmail(
         {
           as: "users",
           model: User,
+          required: true,
           through: { where: { email: userEmail } }
         },
         {

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -1,7 +1,11 @@
 import { Response } from "express";
 import * as t from "io-ts";
 import { errorsToReadableMessages } from "italia-ts-commons/lib/reporters";
-import { IResponse, ResponseErrorInternal, ResponseErrorValidation } from "italia-ts-commons/lib/responses";
+import {
+  IResponse,
+  ResponseErrorInternal,
+  ResponseErrorValidation
+} from "italia-ts-commons/lib/responses";
 import { log } from "./logger";
 
 /**

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -1,10 +1,7 @@
+import { Response } from "express";
 import * as t from "io-ts";
 import { errorsToReadableMessages } from "italia-ts-commons/lib/reporters";
-import {
-  IResponse,
-  ResponseErrorInternal,
-  ResponseErrorValidation
-} from "italia-ts-commons/lib/responses";
+import { IResponse, ResponseErrorInternal, ResponseErrorValidation } from "italia-ts-commons/lib/responses";
 import { log } from "./logger";
 
 /**
@@ -12,6 +9,17 @@ import { log } from "./logger";
  */
 export interface IResponseNoContent extends IResponse<"IResponseNoContent"> {
   readonly value: {};
+}
+
+/**
+ * Returns a no content json response.
+ */
+export function ResponseNoContent(): IResponseNoContent {
+  return {
+    apply: (res: Response) => res.status(204).json({}),
+    kind: "IResponseNoContent",
+    value: {}
+  };
 }
 
 /**


### PR DESCRIPTION
This PR aims to create an endpoint to send an organization its registration documents via email, that is the contract between the organization and IO, and the delegation to the delegate.