### PR TITLE
[#169728025] Change input pattern for public administration search

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -353,7 +353,7 @@ components:
           description: Agency URL
     AdministrationSearchParam:
       type: string
-      pattern: ^[0-9A-Za-z ]{3,}$
+      pattern: ^.{5,}$
       example: comune gioiosa
     AdministrationSearchResult:
       type: object


### PR DESCRIPTION
This PR aims to remove the restrictions on the accepted characters by the public administrations search endpoint, in order to prevent the user from getting an error when performing a search with characters containing accents or not alphanumeric.