### PR TITLE
[#169914858] Send a no content response on successful logout

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -83,8 +83,8 @@ paths:
         - bearerAuth: []
       responses:
         <<: *common-responses
-        200:
-          description: Successful response
+        204:
+          description: No content
   /organizations:
     post:
       description: |-

--- a/src/controllers/__tests__/authenticationController.test.ts
+++ b/src/controllers/__tests__/authenticationController.test.ts
@@ -226,8 +226,8 @@ describe("AuthenticationController#logout", () => {
     expect(mockDel).toHaveBeenCalledWith(mockSessionToken);
     expect(response).toEqual({
       apply: expect.any(Function),
-      kind: "IResponseSuccessJson",
-      value: { message: "ok" }
+      kind: "IResponseNoContent",
+      value: {}
     });
   });
 

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -11,22 +11,23 @@ import {
   IResponseErrorInternal,
   IResponseErrorValidation,
   IResponsePermanentRedirect,
-  IResponseSuccessJson,
   ResponseErrorInternal,
   ResponseErrorValidation,
-  ResponsePermanentRedirect,
-  ResponseSuccessJson
+  ResponsePermanentRedirect
 } from "italia-ts-commons/lib/responses";
 import { UrlFromString } from "italia-ts-commons/lib/url";
 
 import SessionStorage from "../services/sessionStorage";
 import TokenService from "../services/tokenService";
-import { SuccessResponse } from "../types/commons";
 import { SessionToken } from "../types/token";
 import { validateSpidUser, withUserFromRequest } from "../types/user";
 import { getRequiredEnvVar } from "../utils/environment";
 import { log } from "../utils/logger";
-import { withCatchAsInternalError } from "../utils/responses";
+import {
+  IResponseNoContent,
+  ResponseNoContent,
+  withCatchAsInternalError
+} from "../utils/responses";
 
 export default class AuthenticationController {
   constructor(
@@ -99,9 +100,7 @@ export default class AuthenticationController {
   public async logout(
     req: Request
   ): Promise<
-    | IResponseErrorInternal
-    | IResponseErrorValidation
-    | IResponseSuccessJson<SuccessResponse>
+    IResponseErrorInternal | IResponseErrorValidation | IResponseNoContent
   > {
     return withUserFromRequest(req, user =>
       withCatchAsInternalError(async () => {
@@ -112,7 +111,7 @@ export default class AuthenticationController {
           return ResponseErrorInternal(error.message);
         }
 
-        return ResponseSuccessJson({ message: "ok" });
+        return ResponseNoContent();
       })
     );
   }


### PR DESCRIPTION
This PR aims to fix the inconsistency between the implementation and the specification of a successful logout response by changing both of them into a more appropriate no content response.