### PR TITLE
[#169995430] Exclude pre-draft organizations from search results

### DIFF
--- a/src/controllers/organizationController.ts
+++ b/src/controllers/organizationController.ts
@@ -30,7 +30,7 @@ import DocumentService from "../services/documentService";
 import EmailService from "../services/emailService";
 import {
   deleteOrganization,
-  findPublicAdministrationsByName,
+  findAllNotPreDraft,
   getAllOrganizations,
   getOrganizationFromUserEmail,
   getOrganizationInstanceFromDelegateEmail,
@@ -66,9 +66,7 @@ export default class OrganizationController {
         withCatchAsInternalError(
           async () =>
             ResponseSuccessJson({
-              administrations: await findPublicAdministrationsByName(
-                searchParam
-              )
+              administrations: await findAllNotPreDraft(searchParam)
             }),
           "Internal message error"
         )

--- a/src/services/organizationService.ts
+++ b/src/services/organizationService.ts
@@ -82,6 +82,9 @@ export async function findPublicAdministrationsByName(
     where: {
       ipaCode: {
         [Op.in]: publicAdministrations.map(_ => _.cod_amm)
+      },
+      registrationStatus: {
+        [Op.ne]: OrganizationRegistrationStatusEnum.PRE_DRAFT
       }
     }
   });

--- a/src/services/organizationService.ts
+++ b/src/services/organizationService.ts
@@ -47,7 +47,7 @@ import { log } from "../utils/logger";
  * In order to match, the name of the public administration must include each word of the input value in the same order.
  * @param input The value to compare with the name of the public administration.
  */
-export async function findPublicAdministrationsByName(
+export async function findAllNotPreDraft(
   input: string
 ): Promise<ReadonlyArray<FoundAdministration>> {
   const descriptionWords = input


### PR DESCRIPTION
This PR aims to exclude the pre-draft registrations data from the public administrations search results  and to return the original IPA data instead.